### PR TITLE
Include author in prowlarr query

### DIFF
--- a/app/internal/prowlarr/prowlarr.py
+++ b/app/internal/prowlarr/prowlarr.py
@@ -147,7 +147,7 @@ async def query_prowlarr(
     force_refresh: bool = False,
     only_return_if_cached: bool = False,
 ) -> Optional[list[ProwlarrSource]]:
-    query = book_request.title
+    query = book_request.title + " " + book_request.authors[0]
 
     base_url = prowlarr_config.get_base_url(session)
     api_key = prowlarr_config.get_api_key(session)


### PR DESCRIPTION
Found that e-book search results were inaccurate if done by title only. Adding an author name narrows results down considerably.