### PR TITLE
Add auto-download support

### DIFF
--- a/app/internal/models.py
+++ b/app/internal/models.py
@@ -82,6 +82,7 @@ class BookSearchResult(BaseBook):
 class BookWishlistResult(BaseBook):
     requested_by: list[str] = []
     download_error: Optional[str] = None
+    downloaded_file: Optional[str] = None
 
     @property
     def amount_requested(self):
@@ -102,6 +103,9 @@ class BookRequest(BaseBook, table=True):
             nullable=False,
         ),
     )
+    search_attempts: int = Field(default=0)
+    next_search_at: Optional[datetime] = Field(default=None)
+    downloaded_file: Optional[str] = Field(default=None)
 
     __table_args__ = (
         UniqueConstraint("asin", "user_username", name="unique_asin_user"),

--- a/app/internal/prowlarr/prowlarr.py
+++ b/app/internal/prowlarr/prowlarr.py
@@ -106,7 +106,8 @@ async def start_download(
     indexer_id: int,
     requester_username: str,
     book_asin: str,
-) -> ClientResponse:
+    source_title: str = "",
+) -> tuple[ClientResponse, str]:
     prowlarr_config.raise_if_invalid(session)
     base_url = prowlarr_config.get_base_url(session)
     api_key = prowlarr_config.get_api_key(session)
@@ -136,7 +137,7 @@ async def start_download(
                 EventEnum.on_successful_download, requester_username, book_asin
             )
 
-        return response
+        return response, source_title
 
 
 async def query_prowlarr(

--- a/app/internal/query.py
+++ b/app/internal/query.py
@@ -1,5 +1,6 @@
 # what is currently being queried
 from contextlib import contextmanager
+from datetime import datetime, timedelta
 from typing import Literal, Optional
 
 import pydantic
@@ -14,6 +15,10 @@ from app.internal.prowlarr.prowlarr import (
     start_download,
 )
 from app.internal.ranking.download_ranking import rank_sources
+from app.util.log import logger
+
+_BACKOFF_BASE_MINUTES = 15
+_BACKOFF_MAX_MINUTES = 24 * 60  # 24 hours
 
 querying: set[str] = set()
 
@@ -50,10 +55,25 @@ async def query_sources(
     start_auto_download: bool = False,
     only_return_if_cached: bool = False,
     custom_query: Optional[str] = None,
+    reset_backoff: bool = False,
 ) -> QueryResult:
     book = session.exec(select(BookRequest).where(BookRequest.asin == asin)).first()
     if not book:
         raise HTTPException(status_code=404, detail="Book not found")
+
+    # Reset backoff if requested (e.g. manual retry)
+    if reset_backoff:
+        logger.info(
+            "Resetting backoff for book",
+            asin=asin,
+            previous_attempts=book.search_attempts,
+            previous_next_search_at=str(book.next_search_at),
+        )
+        for b in session.exec(select(BookRequest).where(BookRequest.asin == asin)).all():
+            b.search_attempts = 0
+            b.next_search_at = None
+            session.add(b)
+        session.commit()
 
     # Determine the query to use
     query_to_use = custom_query if custom_query else book.title + " " + book.authors[0]
@@ -89,25 +109,59 @@ async def query_sources(
         ranked = await rank_sources(session, client_session, sources, book)
 
         # start download if requested
-        if start_auto_download and not book.downloaded and len(ranked) > 0:
-            resp = await start_download(
-                session=session,
-                client_session=client_session,
-                guid=ranked[0].guid,
-                indexer_id=ranked[0].indexer_id,
-                requester_username=requester_username,
-                book_asin=asin,
-            )
-            if resp.ok:
-                same_books = session.exec(
+        if start_auto_download and not book.downloaded:
+            if len(ranked) > 0:
+                top = ranked[0]
+                logger.info(
+                    "Auto-download selecting top-ranked source",
+                    asin=asin,
+                    title=book.title,
+                    source_title=top.title,
+                    indexer=top.indexer,
+                    guid=top.guid,
+                    protocol=top.protocol,
+                    publish_date=str(top.publish_date),
+                    total_ranked=len(ranked),
+                )
+                resp, source_title = await start_download(
+                    session=session,
+                    client_session=client_session,
+                    guid=top.guid,
+                    indexer_id=top.indexer_id,
+                    requester_username=requester_username,
+                    book_asin=asin,
+                    source_title=top.title,
+                )
+                if resp.ok:
+                    for b in session.exec(
+                        select(BookRequest).where(BookRequest.asin == asin)
+                    ).all():
+                        b.downloaded = True
+                        b.downloaded_file = source_title
+                        session.add(b)
+                    session.commit()
+                else:
+                    raise HTTPException(status_code=500, detail="Failed to start download")
+            else:
+                # No sources found — update backoff for all matching books
+                attempts = book.search_attempts + 1
+                interval_minutes = min(_BACKOFF_BASE_MINUTES * (2 ** attempts), _BACKOFF_MAX_MINUTES)
+                next_search_at = datetime.now() + timedelta(minutes=interval_minutes)
+                logger.info(
+                    "No sources found for auto-download, scheduling retry",
+                    asin=asin,
+                    title=book.title,
+                    attempt=attempts,
+                    next_search_at=str(next_search_at),
+                    interval_minutes=interval_minutes,
+                )
+                for b in session.exec(
                     select(BookRequest).where(BookRequest.asin == asin)
-                ).all()
-                for b in same_books:
-                    b.downloaded = True
+                ).all():
+                    b.search_attempts = attempts
+                    b.next_search_at = next_search_at
                     session.add(b)
                 session.commit()
-            else:
-                raise HTTPException(status_code=500, detail="Failed to start download")
 
         return QueryResult(
             sources=ranked,

--- a/app/internal/ranking/download_ranking.py
+++ b/app/internal/ranking/download_ranking.py
@@ -49,8 +49,8 @@ class CompareSource:
             self._compare_flags,
             self._compare_indexer,
             self._compare_subtitle,
-            self._compare_seeders,
             self._compare_age,
+            self._compare_seeders,
         ]
 
     def __call__(self, a: RankSource, b: RankSource):
@@ -247,11 +247,8 @@ class CompareSource:
     def _compare_age(self, a: RankSource, b: RankSource, next_compare: int) -> int:
         if a.source.protocol != b.source.protocol:
             return self._get_next_compare(next_compare)(a, b, next_compare + 1)
-        if a.source.protocol == "usenet":
-            # With usenets: newer => better
-            return int((a.source.publish_date - b.source.publish_date).total_seconds())
-        # With torrents: older => better
-        return int((b.source.publish_date - a.source.publish_date).total_seconds())
+        # With both usenet and torrents: newer => better
+        return int((a.source.publish_date - b.source.publish_date).total_seconds())
 
 
 def fuzzy_author_narrator_match(

--- a/app/main.py
+++ b/app/main.py
@@ -1,3 +1,5 @@
+import asyncio
+from contextlib import asynccontextmanager
 from typing import Any
 from urllib.parse import quote_plus, urlencode
 
@@ -15,9 +17,11 @@ from app.internal.auth.session_middleware import (
 )
 from app.internal.env_settings import Settings
 from app.internal.models import User
+from app.internal.scheduler import SCHEDULER_INTERVAL_MINUTES, run_auto_download_scheduler
 from app.routers import auth, root, search, settings, wishlist
 from app.util.db import open_session
 from app.util.fetch_js import fetch_scripts
+from app.util.log import logger
 from app.util.redirect import BaseUrlRedirectResponse
 from app.util.templates import templates
 from app.util.toast import ToastException
@@ -28,6 +32,20 @@ fetch_scripts(Settings().app.debug)
 with open_session() as session:
     auth_secret = auth_config.get_auth_secret(session)
 
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    logger.info("Starting auto-download scheduler", interval_minutes=SCHEDULER_INTERVAL_MINUTES)
+    task = asyncio.create_task(run_auto_download_scheduler())
+    yield
+    logger.info("Stopping auto-download scheduler")
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+
 app = FastAPI(
     title="AudioBookRequest",
     debug=Settings().app.debug,
@@ -37,6 +55,7 @@ app = FastAPI(
         Middleware(GZipMiddleware),
     ],
     root_path=Settings().app.base_url.rstrip("/"),
+    lifespan=lifespan,
 )
 
 app.include_router(auth.router)

--- a/app/routers/wishlist.py
+++ b/app/routers/wishlist.py
@@ -71,6 +71,7 @@ def get_wishlist_books(
     for asin, book in distinct_books.items():
         b = BookWishlistResult.model_validate(book)
         b.requested_by = usernames[asin]
+        b.downloaded_file = book.downloaded_file
         if b.downloaded:
             downloaded.append(b)
         else:
@@ -304,7 +305,7 @@ async def download_book(
     client_session: Annotated[ClientSession, Depends(get_connection)],
 ):
     try:
-        resp = await start_download(
+        resp, _ = await start_download(
             session=session,
             client_session=client_session,
             guid=guid,
@@ -339,6 +340,7 @@ async def start_auto_download(
         await query_sources(
             asin=asin,
             start_auto_download=True,
+            reset_backoff=True,
             session=session,
             client_session=client_session,
             requester_username=user.username,

--- a/templates/wishlist_page/wishlist.html
+++ b/templates/wishlist_page/wishlist.html
@@ -1,115 +1,120 @@
 {% extends "wishlist_page/base_wishlist.html" %}
 {% block head %}
-  <title>Wishlist</title>
+    <title>Wishlist</title>
 {% endblock head %}
 {% block content %}
-  <div class="overflow-x-auto h-[75vh] border-b pb-2 border-b-base-200">
-    {% block book_wishlist %}
-      <table id="book-table-body" class="table table-pin-rows min-w-[60rem]">
-        <thead>
-          <tr>
-            <th></th>
-            <th></th>
-            <th>Title</th>
-            <th>Author</th>
-            <th>Narrator</th>
-            <th>Release</th>
-            <th>Length (hrs)</th>
-            <th># Requested</th>
-            <th></th>
-          </tr>
-        </thead>
-        {% if not books %}
-          <div role="alert" class="alert my-2">
-            <span class="stroke-info h-6 w-6 shrink-0">{% include "icons/info-circle.html" %}</span>
-            <span>
-              {% if page.__eq__("wishlist") %}
-                No books on your wishlist. Add some
-                books by heading to the
-                <a preload class="link" href="{{ base_url }}/search">search</a> tab {%
-                elif page.__eq__("downloaded") %} No books have been downloaded yet. {%
-                endif %}
-              </span>
-            </div>
-          {% endif %}
-          <tbody>
-            {% for book in books %}
-              <tr class="text-xs lg:text-sm" id="{{ book.asin }}">
-                <th>{{ loop.index }}</th>
-                <td>
-                  <div class="size-[4rem] lg:size-[6rem]">
-                    {% if book.cover_image %}
-                      <img class="object-cover w-full h-full"
-                           height="64"
-                           width="64"
-                           src="{{ book.cover_image }}"
-                           alt="{{ book.title }}" />
-                    {% else %}
-                      <div class="flex items-center justify-center w-full h-full bg-neutral opacity-30">
-                        {% include "icons/photo-off.html" %}
-                      </div>
+    <div class="overflow-x-auto h-[75vh] border-b pb-2 border-b-base-200">
+        {% block book_wishlist %}
+            <table id="book-table-body" class="table table-pin-rows min-w-[60rem]">
+                <thead>
+                    <tr>
+                        <th></th>
+                        <th></th>
+                        <th>Title</th>
+                        <th>Author</th>
+                        <th>Narrator</th>
+                        <th>Release</th>
+                        <th>Length (hrs)</th>
+                        <th># Requested</th>
+                        {% if page.__eq__("downloaded") %}<th>Downloaded File</th>{% endif %}
+                        <th></th>
+                    </tr>
+                </thead>
+                {% if not books %}
+                    <div role="alert" class="alert my-2">
+                        <span class="stroke-info h-6 w-6 shrink-0">{% include "icons/info-circle.html" %}</span>
+                        <span>
+                            {% if page.__eq__("wishlist") %}
+                                No books on your wishlist. Add some
+                                books by heading to the
+                                <a preload class="link" href="{{ base_url }}/search">search</a> tab {%
+                                elif page.__eq__("downloaded") %} No books have been downloaded yet. {%
+                                endif %}
+                            </span>
+                        </div>
                     {% endif %}
-                  </div>
-                </td>
-                <td>
-                  <div class="flex flex-col">
-                    <a preload
-                       href="{{ base_url }}/search?q={{ book.title+' ' +(book.authors|join(",") ) }}"
-                       class="font-bold text-primary line-clamp-4"
-                       title="{{ book.title }}">{{ book.title }}</a>
-                    {% if book.subtitle %}
-                      <span class="font-semibold line-clamp-4" title="{{ book.subtitle }}">{{ book.subtitle }}</span>
-                    {% endif %}
-                  </div>
-                </td>
-                <td>{{ book.authors|join(", ") }}</td>
-                <td>{{ book.narrators|join(", ") }}</td>
-                <td class="hidden lg:table-cell">{{ book.release_date.strftime("%B %Y") }}</td>
-                <td class="lg:hidden">{{ book.release_date.strftime("%Y") }}</td>
-                <td>{{ book.runtime_length_hrs }}</td>
-                <td title="{{ book.requested_by|join('\n') }}">{{ book.amount_requested }}</td>
-                <td class="grid grid-cols-2 min-w-[8rem] gap-1">
-                  <a preload
-                     title="Torrent Sources"
-                     href="{{ base_url }}/wishlist/sources/{{ book.asin }}"
-                     {% if not user.is_admin() %}disabled{% endif %}
-                     class="btn btn-square">{% include "icons/list.html" %}</a>
-                  {% if book.download_error %}
-                    <button title="Automatic Download"
-                            class="btn btn-square btn-ghost bg-error/70 text-base-100"
-                            disabled>{% include "icons/xmark.html" %}</button>
-                  {% else %}
-                    <button {% if book.downloaded %}title="Downloaded"class="btn btn-square btn-ghost bg-success text-neutral/20" {% else %} title="Automatic Download" class="btn btn-square" {% endif %}
-                            {% if not user.can_download() or book.downloaded %}disabled{% endif %}
-                            hx-post="{{ base_url }}/wishlist/auto-download/{{ book.asin }}"
-                            hx-swap="outerHTML"
-                            hx-target="#book-table-body"
-                            hx-disabled-elt="this">{% include "icons/download.html" %}</button>
-                  {% endif %}
-                  <button title="Remove"
-                          class="btn btn-square"
-                          {% if not user.is_admin() %}disabled{% endif %}
-                          hx-delete="{{ base_url }}/search/request/{{ book.asin }}{%- if page.__eq__('downloaded') -%}?downloaded=true{%- endif -%}"
-                          hx-swap="outerHTML"
-                          hx-target="#book-table-body"
-                          hx-disabled-elt="this">{% include "icons/ban.html" %}</button>
-                  {% if book.downloaded %}
-                    <button class="btn btn-square btn-ghost bg-success text-neutral/20"
-                            disabled
-                            title="Set as downloaded">{% include "icons/checkmark.html" %}</button>
-                  {% else %}
-                    <button class="btn btn-square"
-                            title="Set as downloaded"
-                            hx-patch="{{ base_url }}/wishlist/downloaded/{{ book.asin }}"
-                            hx-swap="outerHTML"
-                            hx-target="#book-table-body"
-                            hx-disabled-elt="this">{% include "icons/checkmark.html" %}</button>
-                  {% endif %}
-                </td>
-              </tr>
-            {% endfor %}
-          </tbody>
-        {% endblock book_wishlist %}
-      </table>
-    </div>
-  {% endblock content %}
+                    <tbody>
+                        {% for book in books %}
+                            <tr class="text-xs lg:text-sm" id="{{ book.asin }}">
+                                <th>{{ loop.index }}</th>
+                                <td>
+                                    <div class="size-[4rem] lg:size-[6rem]">
+                                        {% if book.cover_image %}
+                                            <img class="object-cover w-full h-full"
+                                                 height="64"
+                                                 width="64"
+                                                 src="{{ book.cover_image }}"
+                                                 alt="{{ book.title }}" />
+                                        {% else %}
+                                            <div class="flex items-center justify-center w-full h-full bg-neutral opacity-30">
+                                                {% include "icons/photo-off.html" %}
+                                            </div>
+                                        {% endif %}
+                                    </div>
+                                </td>
+                                <td>
+                                    <div class="flex flex-col">
+                                        <a preload
+                                           href="{{ base_url }}/search?q={{ book.title+' ' +(book.authors|join(",") ) }}"
+                                           class="font-bold text-primary line-clamp-4"
+                                           title="{{ book.title }}">{{ book.title }}</a>
+                                        {% if book.subtitle %}
+                                            <span class="font-semibold line-clamp-4" title="{{ book.subtitle }}">{{ book.subtitle }}</span>
+                                        {% endif %}
+                                    </div>
+                                </td>
+                                <td>{{ book.authors|join(", ") }}</td>
+                                <td>{{ book.narrators|join(", ") }}</td>
+                                <td class="hidden lg:table-cell">{{ book.release_date.strftime("%B %Y") }}</td>
+                                <td class="lg:hidden">{{ book.release_date.strftime("%Y") }}</td>
+                                <td>{{ book.runtime_length_hrs }}</td>
+                                <td title="{{ book.requested_by|join('\n') }}">{{ book.amount_requested }}</td>
+                                {% if page.__eq__("downloaded") %}
+                                    <td class="max-w-[12rem] truncate"
+                                        title="{{ book.downloaded_file or '' }}">{{ book.downloaded_file or "—" }}</td>
+                                {% endif %}
+                                <td class="grid grid-cols-2 min-w-[8rem] gap-1">
+                                    <a preload
+                                       title="Torrent Sources"
+                                       href="{{ base_url }}/wishlist/sources/{{ book.asin }}"
+                                       {% if not user.is_admin() %}disabled{% endif %}
+                                       class="btn btn-square">{% include "icons/list.html" %}</a>
+                                    {% if book.download_error %}
+                                        <button title="Automatic Download"
+                                                class="btn btn-square btn-ghost bg-error/70 text-base-100"
+                                                disabled>{% include "icons/xmark.html" %}</button>
+                                    {% else %}
+                                        <button {% if book.downloaded %}title="Downloaded"class="btn btn-square btn-ghost bg-success text-neutral/20" {% else %} title="Automatic Download" class="btn btn-square" {% endif %}
+                                                {% if not user.can_download() or book.downloaded %}disabled{% endif %}
+                                                hx-post="{{ base_url }}/wishlist/auto-download/{{ book.asin }}"
+                                                hx-swap="outerHTML"
+                                                hx-target="#book-table-body"
+                                                hx-disabled-elt="this">{% include "icons/download.html" %}</button>
+                                    {% endif %}
+                                    <button title="Remove"
+                                            class="btn btn-square"
+                                            {% if not user.is_admin() %}disabled{% endif %}
+                                            hx-delete="{{ base_url }}/search/request/{{ book.asin }}{%- if page.__eq__('downloaded') -%}?downloaded=true{%- endif -%}"
+                                            hx-swap="outerHTML"
+                                            hx-target="#book-table-body"
+                                            hx-disabled-elt="this">{% include "icons/ban.html" %}</button>
+                                    {% if book.downloaded %}
+                                        <button class="btn btn-square btn-ghost bg-success text-neutral/20"
+                                                disabled
+                                                title="Set as downloaded">{% include "icons/checkmark.html" %}</button>
+                                    {% else %}
+                                        <button class="btn btn-square"
+                                                title="Set as downloaded"
+                                                hx-patch="{{ base_url }}/wishlist/downloaded/{{ book.asin }}"
+                                                hx-swap="outerHTML"
+                                                hx-target="#book-table-body"
+                                                hx-disabled-elt="this">{% include "icons/checkmark.html" %}</button>
+                                    {% endif %}
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                {% endblock book_wishlist %}
+            </table>
+        </div>
+    {% endblock content %}


### PR DESCRIPTION
Added a service that will auto download books in the Wishlist. It will attempt a download as soon as it is requested, then again after 15 minutes and exponentially back off a maximum of 24 hours between attempts.

Also changed the way in which searches are ranked. I have found with some books that grabbing the older entries results in review copies and not retail. We'll see how this new sorting goes.

Overall, the changes in this commit are pretty meh, but they work so :shrug: 